### PR TITLE
Add missing types for generateApolloClient

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,19 @@
+import type { ApolloClient } from '@apollo/client';
+import type { WebSocketLink } from 'apollo-link-ws';
+
+export function generateApolloClient(
+  auth?: any,
+  gqlEndpoint: string,
+  headers?: {
+    [key: string]: any;
+  },
+  publicRole?: string,
+  cache?: any,
+): {
+  client: ApolloClient;
+  wsLink: WebSocketLink | null;
+};
+
 export function NhostApolloProvider(
   auth: any,
   gqlEndpoint: string,


### PR DESCRIPTION
Hi, just wanna get rid of the pesky Typescript error.

BTW, been trying out your service, and it's been amazing so far. Hope you guys can set up a server in Southeast Asia.