### PR TITLE
feat: add support for headers from previousContext

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,10 +96,11 @@ function generateApolloClient({
     uri,
   });
 
-  const authLink = setContext(() => {
+  const authLink = setContext((_, previousContext) => {
     return {
       headers: {
         ...getAuthHeaders(),
+        ...(previousContext?.headers || {}),
       },
     };
   });


### PR DESCRIPTION
authLink does not consider headers that might need to be set at a later point in time through the use of setContext. It ignores the previousContext.
Further explanation with example on how this fix will be used can be viewed here https://github.com/nhost/react-apollo/issues/25